### PR TITLE
Ignore remaining intermediate files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 /dgamelaunch
 /nethackstub
 /.depend
+/*.o
+/virus
+/ee


### PR DESCRIPTION
Add intermediate object files, virus, and ee executables to gitignore.
