### PR TITLE
Some build system and portability fixes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -9,6 +9,7 @@ mandir = @mandir@
 
 CC = @CC@
 LIBS = @LIBS@
+LEXLIBS = @LEXLIBS@
 CFLAGS = @CFLAGS@
 INSTALL = @INSTALL@
 LEX = @LEX@
@@ -30,7 +31,7 @@ OBJS = $(SRCS:.c=.o)
 all: .depend $(NAME) $(EDITORS)
 
 $(NAME): $(OBJS)
-	$(CC) $(CFLAGS) -o $@ $(OBJS) $(LIBS)
+	$(CC) $(CFLAGS) -o $@ $(OBJS) $(LIBS) $(LEXLIBS)
 
 ee: ee.c
 	$(CC) $(CFLAGS) -o $@ $< $(LIBS)

--- a/autogen.sh
+++ b/autogen.sh
@@ -3,8 +3,7 @@
 echo "Generating configuration files..."
 echo
 
-autoconf
-autoheader
+autoreconf
 # evil
 rm -rf autom4te.cache
 ./configure "$@"

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ if test -z "$LEX"; then
    AC_MSG_ERROR([lex or flex not found.])
 fi
 
-LIBS="$LIBS $LEXLIB"
+LEXLIBS="$LEXLIB"
 
 AC_CHECK_LIB(pthread, pthread_create, [], [AC_MSG_ERROR([need pthreads])])
 
@@ -26,7 +26,7 @@ fi
 
 case "$(uname -s)" in
   Linux | *BSD)
-    LIBS="$LIBS -lutil -lcrypt"
+    MY_LIBS="$MY_LIBS -lutil -lcrypt"
     AC_DEFINE(NOSTREAMS, 1, [Don't use SVR4 streams support in ttyrec.])
   ;;
 esac
@@ -108,7 +108,7 @@ AC_ARG_WITH(sqlite-db,
 if test "$enable_sqlite" = yes; then
    AC_MSG_RESULT([Using SQLite for the database, located at $dgl_sqlite_db])
    AC_DEFINE(USE_SQLITE3,1,[Use SQLite for the database instead of flat text file.])
-   LIBS="$LIBS -lsqlite3"
+   MY_LIBS="$MY_LIBS -lsqlite3"
    AC_DEFINE_UNQUOTED(USE_SQLITE_DB, "$dgl_sqlite_db", [Path and filename of the SQLite database.])
 fi
 
@@ -158,7 +158,7 @@ if test "$enable_shmem" = yes; then
    AC_CHECK_HEADERS([sys/shm.h], [], [AC_MSG_ERROR([sys/shm.h not found.])], [])
    AC_MSG_RESULT([Enabled showing number of watchers.])
    AC_DEFINE(USE_SHMEM,1,[Use shared memory block])
-   LIBS="$LIBS -lrt"
+   MY_LIBS="$MY_LIBS -lrt"
    # or -pthread?
 fi
 
@@ -184,8 +184,10 @@ else
 fi
 
 
+LIBS="$LIBS $MY_LIBS"
 
 AC_SUBST(SETPROCTITLE_C)
+AC_SUBST(LEXLIBS)
 
 AC_CONFIG_FILES(Makefile)
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,7 @@ fi
 
 LIBS="$LIBS $LEXLIB"
 
-AC_CHECK_LIB(pthread, pthread_create, [PTHREAD_CFLAGS+=-lpthread])
+AC_CHECK_LIB(pthread, pthread_create, [], [AC_MSG_ERROR([need pthreads])])
 
 AC_CHECK_PROGS(YACC, 'bison -y' byacc yacc)
 if test -z "$YACC"; then
@@ -48,7 +48,7 @@ AC_PATH_PROG(MAKEDEPEND, makedepend)
 AC_MSG_CHECKING([how to generate dependency info])
 
 if test "$ac_cv_c_compiler_gnu" = yes; then
-  CFLAGS="$CFLAGS -Wall -Wno-unused $PTHREAD_CFLAGS"
+  CFLAGS="$CFLAGS -Wall -Wno-unused"
   MKDEP="$CC -MM"
   MKDEP_DIRECT="> .depend"
   AC_MSG_RESULT(gcc)

--- a/dgamelaunch.c
+++ b/dgamelaunch.c
@@ -66,14 +66,14 @@
 # include <sqlite3.h>
 #endif
 
-#ifndef __FreeBSD__
-# ifdef __APPLE__
-#  include <unistd.h>
-# else
-#  include <crypt.h>
-# endif
-#else
+#if defined(__FreeBSD__)
 # include <libutil.h>
+#elif defined(__NetBSD__)
+# include <util.h>
+#elif defined(__APPLE__)
+# include <unistd.h>
+#else
+# include <crypt.h>
 #endif
 
 #ifdef __linux__

--- a/ttyplay.c
+++ b/ttyplay.c
@@ -58,7 +58,7 @@
 #include "io.h"
 #include "stripgfx.h"
 
-#if defined(__MACH__) || defined(__NetBSD__)
+#if defined(__MACH__) || defined(__FreeBSD__) || defined(__NetBSD__)
 typedef void (*sighandler_t)(int);
 #endif
 

--- a/ttyplay.c
+++ b/ttyplay.c
@@ -58,7 +58,7 @@
 #include "io.h"
 #include "stripgfx.h"
 
-#ifdef __MACH__
+#if defined(__MACH__) || defined(__NetBSD__)
 typedef void (*sighandler_t)(int);
 #endif
 


### PR DESCRIPTION
Not explicitly mentioned in the commit messages, but it also didn't compile on Linux (an older debian and a newer arch) for me. 

As for the build system, I'm by no means an autohell expert, but AFAIK you can't mess with $LIBS because $LIBS will be taken into consideration when running feature test macros. In particular, building on Linux blew up because -fl has the nasty property that it requires the program linked against it to export a yylex symbol, which most feature test macros do not do (in particular, the test for libncursesw wrongly failed because it was linked with -lfl))

Also it's wrong to have -lpthread in $CFLAGS, it belongs into $LIBS (but should be put there by the respective macro)