### PR TITLE
Fixed pass-the-hash vulnerability

### DIFF
--- a/dgamelaunch.c
+++ b/dgamelaunch.c
@@ -2057,10 +2057,16 @@ passwordgood (char *cpw)
   crypted = crypt (cpw, cpw);
   if (crypted == NULL)
       return 0;
+
+#ifdef USE_SQLITE3
   if (!strncmp (crypted, me->password, DGL_PASSWDLEN))
     return 1;
+
+#else
   if (!strncmp (cpw, me->password, DGL_PASSWDLEN))
     return 1;
+
+#endif
 
   return 0;
 }


### PR DESCRIPTION
In reference to #10,  I fixed the pass-the-hash vulnerability.

The vulnerability was tested before and after I made changes using matsuu's docker image for a Nethack server. Using the hash as the password did not log me in once the ifdefs were added.