### PR TITLE
Fix V773 warning from PVS-Studio Static Analyzer

### DIFF
--- a/dgamelaunch.c
+++ b/dgamelaunch.c
@@ -1654,8 +1654,10 @@ domailuser (char *username)
 	    DGL_MAILMSGLEN);
   mvaddstr (7, 1, "=> ");
 
-  if (mygetnstr (message, DGL_MAILMSGLEN, 1) != OK)
+  if (mygetnstr (message, DGL_MAILMSGLEN, 1) != OK) {
+      if (spool_fn) free(spool_fn);
       return;
+  }
 
   for (i = 0; i < strlen (message); i++)
     {
@@ -2558,6 +2560,7 @@ purge_stale_locks (int game)
 	  {
 	    nocbreak(); /* leave half-delay */
 	    cbreak();
+            if (fn) free(fn);
 	    return 0;
 	  }
 	  mvprintw (3, 50 + strlen(myconfig[game]->game_name), "%d%s", seconds, (seconds > 9) ? "" : " ");

--- a/dgl-common.c
+++ b/dgl-common.c
@@ -223,7 +223,11 @@ dgl_exec_cmdqueue(struct dg_cmdpart *queue, int game, struct dg_user *me)
     p1 = (char *)malloc(1024);
     p2 = (char *)malloc(1024);
 
-    if (!p1 || !p2) return 1;
+    if (!p1 || !p2) {
+        if (p1) free(p1);
+        if (p2) free(p2);
+        return 1;
+    }
 
     return_from_submenu = 0;
 
@@ -635,6 +639,8 @@ populate_games (int xgame, int *l, struct dg_user *me)
 	  debug_write("cannot open inprogress-dir");
 	  graceful_exit (140);
       }
+      free(dir);
+      dir = NULL;
 
    while ((pdirent = readdir (pdir)))
     {

--- a/ee.c
+++ b/ee.c
@@ -2101,8 +2101,10 @@ int noverify;
 		ans = get_string(changes_made_prompt, TRUE);
 		if (toupper(*ans) == toupper(*yes_char))
 			text_changes = FALSE;
-		else
+                else {
+                        free(ans);
 			return(0);
+                }
 		free(ans);
 	}
 	


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
The function was exited without releasing a pointer.
A memory leak is possible.