### PR TITLE
Track idle by input

### DIFF
--- a/dgamelaunch.c
+++ b/dgamelaunch.c
@@ -2500,7 +2500,7 @@ purge_stale_locks (int game)
   while ((dent = readdir (pdir)) != NULL)
     {
       FILE *ipfile;
-      char *colon, *fn;
+      char *colon, *fn, *fn_in;
       char buf[16];
       pid_t pid;
       size_t len;
@@ -2524,6 +2524,24 @@ purge_stale_locks (int game)
       fn = malloc (len);
 
       snprintf (fn, len, "%s%s", dgl_format_str(game, me, myconfig[game]->inprogressdir, NULL), dent->d_name);
+
+      /* skip .in files */
+      if (len >= 3) {
+        char *tmp = fn + len - 4;
+        if (!strcmp(tmp, ".in")) {
+          fn[len-4] = '\0';
+          printf("%s", fn);
+          /* unlink .in file if it's orphaned */
+          if (stat(fn, NULL)) {
+            fn[len-4] = '.';
+            unlink(fn);
+          }
+          free(fn);
+          continue;
+        }
+      }
+      fn_in = malloc(len + 3);
+      snprintf (fn_in, len + 3, "%s.in", fn);
 
       if (!(ipfile = fopen (fn, "r"))) {
 	  debug_write("purge_stale_locks fopen inprogressdir fail");
@@ -2608,6 +2626,8 @@ purge_stale_locks (int game)
       /* Don't remove the lock file until the process is dead. */
       unlink (fn);
       free (fn);
+      unlink (fn_in);
+      free (fn_in);
     }
 
   closedir (pdir);

--- a/dgamelaunch.c
+++ b/dgamelaunch.c
@@ -2504,6 +2504,7 @@ purge_stale_locks (int game)
       char buf[16];
       pid_t pid;
       size_t len;
+      struct stat pstat;
       int seconds = 0;
 
       if (!strcmp (dent->d_name, ".") || !strcmp (dent->d_name, ".."))
@@ -2515,10 +2516,6 @@ purge_stale_locks (int game)
 	  debug_write("purge_stale_locks !colon");
         graceful_exit (201);
       }
-      if (colon - dent->d_name != strlen(me->username))
-        continue;
-      if (strncmp (dent->d_name, me->username, colon - dent->d_name))
-        continue;
 
       len = strlen (dent->d_name) + strlen(dgl_format_str(game, me, myconfig[game]->inprogressdir, NULL)) + 1;
       fn = malloc (len);
@@ -2526,13 +2523,13 @@ purge_stale_locks (int game)
       snprintf (fn, len, "%s%s", dgl_format_str(game, me, myconfig[game]->inprogressdir, NULL), dent->d_name);
 
       /* skip .in files */
-      if (len >= 3) {
+      if (len >= 4) {
         char *tmp = fn + len - 4;
         if (!strcmp(tmp, ".in")) {
           fn[len-4] = '\0';
           printf("%s", fn);
           /* unlink .in file if it's orphaned */
-          if (stat(fn, NULL)) {
+          if (stat(fn, &pstat)) {
             fn[len-4] = '.';
             unlink(fn);
           }
@@ -2540,6 +2537,12 @@ purge_stale_locks (int game)
           continue;
         }
       }
+
+      if (colon - dent->d_name != strlen(me->username))
+        continue;
+      if (strncmp (dent->d_name, me->username, colon - dent->d_name))
+        continue;
+
       fn_in = malloc(len + 3);
       snprintf (fn_in, len + 3, "%s.in", fn);
 

--- a/ttyrec.h
+++ b/ttyrec.h
@@ -21,7 +21,7 @@ extern void doshell (int, char *);
 extern void finish (int);
 extern void remove_ipfile (void);
 
-extern int ttyrec_main (int, char *username, char *ttyrec_path, char* ttyrec_filename);
+extern int ttyrec_main (int, char *username, char *ttyrec_path, char *inprog_path, char* ttyrec_filename);
 
 extern pid_t child; /* nethack process */
 extern int master, slave;


### PR DESCRIPTION
Currently dgamelaunch checks the mtime of the ttyrec to determine idle time of games for the watching games menu.
Some games continue to update the screen while the user is idle (e.g. NetHack-setseed with realtime UI-clock enabled on the status bar), which results in idle games being displayed as active.

This PR introduces an additional file in the inprogressdir, which is the same as the lockfile path but with '.in' appended.
Any user input is copied live to this file.
The watch menu checks the mtime of this file instead, to show the idle timer for a given game.
Additional routines were implemented to clean up this extra file, and to exclude it from being treated as a lockfile.
This is because currently all files in inprogressdir are treated as lockfiles. With this PR, those ending in '.in' are excluded, and also removed if they are orphans (if the same file without the '.in' suffix does not exist, they are considered orphans).